### PR TITLE
sapphire: rootdir: : Display/IRQ tuning removal

### DIFF
--- a/rootdir/etc/init.sapphire.perf.rc
+++ b/rootdir/etc/init.sapphire.perf.rc
@@ -30,8 +30,3 @@ on property:vendor.post_boot.parsed=1
     write /dev/cpuctl/nnapi-hal/cpu.shares 20480
     write /dev/cpuctl/rt/cpu.shares 20480
     write /dev/cpuctl/top-app/cpu.shares 20480
-
-    # Miscellaneous
-    write /sys/module/drm/parameters/vblankoffdelay -1
-    write /proc/irq/209/smp_affinity_list 7
-    write /proc/irq/218/smp_affinity_list 6


### PR DESCRIPTION
Reverts explicit kernel tuning settings that conflict with existing IRQ affinity scripts and negatively impact power consumption.

- Removed 'vblankoffdelay -1' which kept the display pipeline constantly on, draining battery during idle screen time.
- Removed explicit IRQ affinity writes (209/218) to prevent race conditions and conflicts with the standard 'write_irq_affinity' calls.